### PR TITLE
Added interface with constants for encoding

### DIFF
--- a/src/zcl_mockup_loader.clas.abap
+++ b/src/zcl_mockup_loader.clas.abap
@@ -490,11 +490,11 @@ method read_zip.
     zcx_mockup_loader_error=>raise( msg = |Cannot read { i_name }| code = 'ZF' ). "#EC NOTEXT
   endif.
 
-  " Remove unicide signatures
+  " Remove unicode signatures
   case mv_encoding.
-    when '4110'. " UTF-8
+    when zif_mockup_loader_constants=>encoding_utf8.
       shift l_xstring left deleting leading  cl_abap_char_utilities=>byte_order_mark_utf8 in byte mode.
-    when '4103'. " UTF-16LE
+    when zif_mockup_loader_constants=>encoding_utf16.
       shift l_xstring left deleting leading  cl_abap_char_utilities=>byte_order_mark_little in byte mode.
   endcase.
 
@@ -517,7 +517,7 @@ method SET_PARAMS.
   endif.
 
   if i_encoding is initial.
-    me->mv_encoding = '4103'. " UTF16
+    me->mv_encoding = zif_mockup_loader_constants=>encoding_utf16.
   else.
     me->mv_encoding = i_encoding.
   endif.

--- a/src/zif_mockup_loader_constants.intf.abap
+++ b/src/zif_mockup_loader_constants.intf.abap
@@ -1,0 +1,8 @@
+INTERFACE zif_mockup_loader_constants
+  PUBLIC .
+
+  " Codepages
+  CONSTANTS encoding_utf8 TYPE abap_encoding VALUE '4110'.
+  CONSTANTS encoding_utf16 TYPE abap_encoding VALUE '4103'.
+
+ENDINTERFACE.

--- a/src/zif_mockup_loader_constants.intf.xml
+++ b/src/zif_mockup_loader_constants.intf.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_INTF" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOINTERF>
+    <CLSNAME>ZIF_MOCKUP_LOADER_CONSTANTS</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Constants for mockup loader</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <UNICODE>X</UNICODE>
+   </VSEOINTERF>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
Because the use of '4110' or '4103' is a bit cumbersome, I added an interface with constants for the encoding.
I also added the use of it in the class `ZCL_MOCKUP_LOADER`.